### PR TITLE
add metrics for scale down debugging

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -134,7 +134,7 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 		}, []string{"statefulset_name"}),
 		scaleDownBoolean: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "rollout_operator_scale_down_boolean",
-			Help: "Boolean for whether an invester pod is ready to scale down.",
+			Help: "Boolean for whether an ingester pod is ready to scale down.",
 		}, []string{"scale_down_pod_name"}),
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -71,6 +71,8 @@ type RolloutController struct {
 	groupReconcileFailed      *prometheus.CounterVec
 	groupReconcileDuration    *prometheus.HistogramVec
 	groupReconcileLastSuccess *prometheus.GaugeVec
+	desiredReplicas           *prometheus.GaugeVec
+	scaleDownBoolean          *prometheus.GaugeVec
 
 	// Keep track of discovered rollout groups. We use this information to delete metrics
 	// related to rollout groups that have been decommissioned.
@@ -126,6 +128,14 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 			Name: "rollout_operator_last_successful_group_reconcile_timestamp_seconds",
 			Help: "Timestamp of the last successful reconcile for a specific rollout group.",
 		}, []string{"rollout_group"}),
+		desiredReplicas: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_statefulset_desired_replicas",
+			Help: "Desired replicas of a Statefulset parsed from CRD.",
+		}, []string{"statefulset_name"}),
+		scaleDownBoolean: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "rollout_operator_scale_down_boolean",
+			Help: "Boolean for whether an invester pod is ready to scale down.",
+		}, []string{"scale_down_pod_name"}),
 	}
 
 	return c
@@ -209,7 +219,7 @@ func (c *RolloutController) reconcile(ctx context.Context) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "RolloutController.reconcile()")
 	defer span.Finish()
 
-	level.Info(c.logger).Log("msg", "reconcile started (minReadySeconds version)")
+	level.Info(c.logger).Log("msg", "reconcile started")
 
 	sets, err := c.listStatefulSetsWithRolloutGroup()
 	if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -67,12 +67,14 @@ type RolloutController struct {
 	stopCh chan struct{}
 
 	// Metrics.
-	groupReconcileTotal       *prometheus.CounterVec
-	groupReconcileFailed      *prometheus.CounterVec
-	groupReconcileDuration    *prometheus.HistogramVec
-	groupReconcileLastSuccess *prometheus.GaugeVec
-	desiredReplicas           *prometheus.GaugeVec
-	scaleDownBoolean          *prometheus.GaugeVec
+	groupReconcileTotal        *prometheus.CounterVec
+	groupReconcileFailed       *prometheus.CounterVec
+	groupReconcileDuration     *prometheus.HistogramVec
+	groupReconcileLastSuccess  *prometheus.GaugeVec
+	desiredReplicas            *prometheus.GaugeVec
+	scaleDownBoolean           *prometheus.GaugeVec
+	downscaleProbeTotal        *prometheus.CounterVec
+	downscaleProbeFailureTotal *prometheus.CounterVec
 
 	// Keep track of discovered rollout groups. We use this information to delete metrics
 	// related to rollout groups that have been decommissioned.
@@ -135,6 +137,14 @@ func NewRolloutController(kubeClient kubernetes.Interface, restMapper meta.RESTM
 		scaleDownBoolean: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "rollout_operator_scale_down_boolean",
 			Help: "Boolean for whether an ingester pod is ready to scale down.",
+		}, []string{"scale_down_pod_name"}),
+		downscaleProbeTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rollout_operator_downscale_probe_total",
+			Help: "Total number of downscale probes.",
+		}, []string{"scale_down_pod_name"}),
+		downscaleProbeFailureTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rollout_operator_downscale_probe_failure_total",
+			Help: "Total number of failed downscale probes.",
 		}, []string{"scale_down_pod_name"}),
 	}
 

--- a/pkg/controller/custom_resource_replicas.go
+++ b/pkg/controller/custom_resource_replicas.go
@@ -50,7 +50,7 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 		var desiredReplicas int32
 		if sts.GetAnnotations()[config.RolloutDelayedDownscaleAnnotationKey] == "boolean" {
 			level.Debug(c.logger).Log("msg", "boolean scaling logic")
-			desiredReplicas, err = checkScalingBoolean(ctx, c.logger, sts, client, currentReplicas, referenceResourceDesiredReplicas, c.scaleDownBoolean)
+			desiredReplicas, err = checkScalingBoolean(ctx, c.logger, sts, client, currentReplicas, referenceResourceDesiredReplicas, c.scaleDownBoolean, c.downscaleProbeTotal, c.downscaleProbeFailureTotal)
 		} else {
 			desiredReplicas, err = checkScalingDelay(ctx, c.logger, sts, client, currentReplicas, referenceResourceDesiredReplicas)
 		}

--- a/pkg/controller/custom_resource_replicas.go
+++ b/pkg/controller/custom_resource_replicas.go
@@ -36,6 +36,7 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 		referenceResource := fmt.Sprintf("%s/%s", referenceGVR.Resource, referenceName)
 
 		referenceResourceDesiredReplicas := scaleObj.Spec.Replicas
+		c.desiredReplicas.WithLabelValues(sts.GetName()).Set(float64(referenceResourceDesiredReplicas))
 		if currentReplicas == referenceResourceDesiredReplicas {
 			updateStatusReplicasOnReferenceResourceIfNeeded(ctx, c.logger, c.dynamicClient, sts, scaleObj, referenceGVR, referenceName, referenceResourceDesiredReplicas)
 			cancelDelayedDownscaleIfConfigured(ctx, c.logger, sts, client, referenceResourceDesiredReplicas)
@@ -49,7 +50,7 @@ func (c *RolloutController) adjustStatefulSetsGroupReplicasToMirrorResource(ctx 
 		var desiredReplicas int32
 		if sts.GetAnnotations()[config.RolloutDelayedDownscaleAnnotationKey] == "boolean" {
 			level.Debug(c.logger).Log("msg", "boolean scaling logic")
-			desiredReplicas, err = checkScalingBoolean(ctx, c.logger, sts, client, currentReplicas, referenceResourceDesiredReplicas)
+			desiredReplicas, err = checkScalingBoolean(ctx, c.logger, sts, client, currentReplicas, referenceResourceDesiredReplicas, c.scaleDownBoolean)
 		} else {
 			desiredReplicas, err = checkScalingDelay(ctx, c.logger, sts, client, currentReplicas, referenceResourceDesiredReplicas)
 		}

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/api/apps/v1"
@@ -43,7 +44,7 @@ func cancelDelayedDownscaleIfConfigured(ctx context.Context, logger log.Logger, 
 	callCancelDelayedDownscale(ctx, logger, httpClient, endpoints)
 }
 
-func checkScalingBoolean(ctx context.Context, logger log.Logger, sts *v1.StatefulSet, httpClient httpClient, currentReplicas, desiredReplicas int32) (updatedDesiredReplicas int32, _ error) {
+func checkScalingBoolean(ctx context.Context, logger log.Logger, sts *v1.StatefulSet, httpClient httpClient, currentReplicas, desiredReplicas int32, scaleDownBooleanMetric *prometheus.GaugeVec) (updatedDesiredReplicas int32, _ error) {
 	if desiredReplicas >= currentReplicas {
 		return desiredReplicas, nil
 	}
@@ -53,7 +54,7 @@ func checkScalingBoolean(ctx context.Context, logger log.Logger, sts *v1.Statefu
 		return currentReplicas, err
 	}
 	downscaleEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), getStsSvcName(sts), int(desiredReplicas), int(currentReplicas), prepareURL)
-	scalableBooleans, err := callPerpareDownscaleAndReturnScalable(ctx, logger, httpClient, downscaleEndpoints)
+	scalableBooleans, err := callPerpareDownscaleAndReturnScalable(ctx, logger, httpClient, downscaleEndpoints, scaleDownBooleanMetric)
 	if err != nil {
 		return currentReplicas, fmt.Errorf("failed prepare pods for delayed downscale: %v", err)
 	}
@@ -217,7 +218,7 @@ func createPrepareDownscaleEndpoints(namespace, statefulsetName, serviceName str
 	return eps
 }
 
-func callPerpareDownscaleAndReturnScalable(ctx context.Context, logger log.Logger, client httpClient, endpoints []endpoint) (map[int]bool, error) {
+func callPerpareDownscaleAndReturnScalable(ctx context.Context, logger log.Logger, client httpClient, endpoints []endpoint, scaleDownBooleanMetric *prometheus.GaugeVec) (map[int]bool, error) {
 	if len(endpoints) == 0 {
 		return nil, fmt.Errorf("no endpoints")
 	}
@@ -253,12 +254,14 @@ func callPerpareDownscaleAndReturnScalable(ctx context.Context, logger log.Logge
 			scalableMu.Lock()
 			if resp.StatusCode == 200 {
 				scalable[ep.replica] = true
+				scaleDownBooleanMetric.WithLabelValues(ep.podName).Set(1)
 			} else {
 				if resp.StatusCode != 425 {
 					// 425 too early
 					level.Error(epLogger).Log("msg", "downscale POST got unexpected status", resp.StatusCode)
 				}
 				scalable[ep.replica] = false
+				scaleDownBooleanMetric.WithLabelValues(ep.podName).Set(0)
 			}
 			scalableMu.Unlock()
 

--- a/pkg/controller/delay.go
+++ b/pkg/controller/delay.go
@@ -44,7 +44,7 @@ func cancelDelayedDownscaleIfConfigured(ctx context.Context, logger log.Logger, 
 	callCancelDelayedDownscale(ctx, logger, httpClient, endpoints)
 }
 
-func checkScalingBoolean(ctx context.Context, logger log.Logger, sts *v1.StatefulSet, httpClient httpClient, currentReplicas, desiredReplicas int32, scaleDownBooleanMetric *prometheus.GaugeVec) (updatedDesiredReplicas int32, _ error) {
+func checkScalingBoolean(ctx context.Context, logger log.Logger, sts *v1.StatefulSet, httpClient httpClient, currentReplicas, desiredReplicas int32, scaleDownBooleanMetric *prometheus.GaugeVec, downscaleProbeTotal *prometheus.CounterVec, downscaleProbeFailureTotal *prometheus.CounterVec) (updatedDesiredReplicas int32, _ error) {
 	if desiredReplicas >= currentReplicas {
 		return desiredReplicas, nil
 	}
@@ -54,7 +54,7 @@ func checkScalingBoolean(ctx context.Context, logger log.Logger, sts *v1.Statefu
 		return currentReplicas, err
 	}
 	downscaleEndpoints := createPrepareDownscaleEndpoints(sts.Namespace, sts.GetName(), getStsSvcName(sts), int(desiredReplicas), int(currentReplicas), prepareURL)
-	scalableBooleans, err := callPerpareDownscaleAndReturnScalable(ctx, logger, httpClient, downscaleEndpoints, scaleDownBooleanMetric)
+	scalableBooleans, err := callPerpareDownscaleAndReturnScalable(ctx, logger, httpClient, downscaleEndpoints, scaleDownBooleanMetric, downscaleProbeTotal, downscaleProbeFailureTotal)
 	if err != nil {
 		return currentReplicas, fmt.Errorf("failed prepare pods for delayed downscale: %v", err)
 	}
@@ -218,7 +218,7 @@ func createPrepareDownscaleEndpoints(namespace, statefulsetName, serviceName str
 	return eps
 }
 
-func callPerpareDownscaleAndReturnScalable(ctx context.Context, logger log.Logger, client httpClient, endpoints []endpoint, scaleDownBooleanMetric *prometheus.GaugeVec) (map[int]bool, error) {
+func callPerpareDownscaleAndReturnScalable(ctx context.Context, logger log.Logger, client httpClient, endpoints []endpoint, scaleDownBooleanMetric *prometheus.GaugeVec, downscaleProbeTotal *prometheus.CounterVec, downscaleProbeFailureTotal *prometheus.CounterVec) (map[int]bool, error) {
 	if len(endpoints) == 0 {
 		return nil, fmt.Errorf("no endpoints")
 	}
@@ -238,8 +238,10 @@ func callPerpareDownscaleAndReturnScalable(ctx context.Context, logger log.Logge
 			epLogger := log.With(logger, "pod", ep.podName, "url", target)
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, nil)
+			downscaleProbeTotal.WithLabelValues(ep.podName).Inc()
 			if err != nil {
 				level.Error(epLogger).Log("msg", "error creating HTTP POST request to endpoint", "err", err)
+				downscaleProbeFailureTotal.WithLabelValues(ep.podName).Inc()
 				return err
 			}
 
@@ -258,6 +260,7 @@ func callPerpareDownscaleAndReturnScalable(ctx context.Context, logger log.Logge
 			} else {
 				if resp.StatusCode != 425 {
 					// 425 too early
+					downscaleProbeFailureTotal.WithLabelValues(ep.podName).Inc()
 					level.Error(epLogger).Log("msg", "downscale POST got unexpected status", resp.StatusCode)
 				}
 				scalable[ep.replica] = false


### PR DESCRIPTION
This PR introduces new Prometheus gauge metrics, `rollout_operator_scale_down_boolean` and `rollout_operator_statefulset_desired_replicas`, to track whether an ingester pod is ready to scale down. The metric enhances observability by providing real-time feedback on the scaling readiness of pods within the rollout process.